### PR TITLE
Removed checklist in issue template since GH thinks that's a 'todo' list

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -12,9 +12,9 @@ Available months: [Example: July, Aug, Sept | Example: Not October | Example: Al
 
 _We meet on the second Thursday of the month generally. You can use this handy-dandy list to check dates:_
 
-- [ ] Thu Jul 14 2016
-- [ ] Thu Aug 11 2016
-- [ ] Thu Sep 08 2016
-- [ ] Thu Oct 13 2016
-- [ ] Thu Nov 10 2016
-- [ ] Thu Dec 08 2016
+- Thu Jul 14 2016
+- Thu Aug 11 2016
+- Thu Sep 08 2016
+- Thu Oct 13 2016
+- Thu Nov 10 2016
+- Thu Dec 08 2016


### PR DESCRIPTION
@asabaylus or @elgreg: simple change... GH thinks a list of checkboxes in an issue is a "todo" list of things to do before that issue is complete, so I just changed the markdown for the upcoming dates to be a bullet list instead.
